### PR TITLE
Slim and SASS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An [Atom package](https://atom.io/packages/rails-partials) to easily create part
 
 ## Features
 * Support for `.erb`, `.haml` and `.slim` files.
-* Support for `.scss` files.
+* Support for `.scss` and `.sass` files.
 * Support for partials in other directories, when a partial is created with a name with slashes for example 'shared/footer', the partial is going to be created at `app/views/shared/_footer.html.yourext`
 * Support to send parameters into partials, 'shared/footer user:@user var:@var' generates <%= render 'shared/footer', user: @user, var: @var %>
 * Configuration to show or not show the generated partial in a new tab (defaults to true)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An [Atom package](https://atom.io/packages/rails-partials) to easily create partials for your ruby on rails application.
 
 ## Features
-* Support for `.erb` and `.haml` files.
+* Support for `.erb`, `.haml` and `.slim` files.
 * Support for `.scss` files.
 * Support for partials in other directories, when a partial is created with a name with slashes for example 'shared/footer', the partial is going to be created at `app/views/shared/_footer.html.yourext`
 * Support to send parameters into partials, 'shared/footer user:@user var:@var' generates <%= render 'shared/footer', user: @user, var: @var %>

--- a/lib/prompt-helper.coffee
+++ b/lib/prompt-helper.coffee
@@ -61,7 +61,7 @@ class PromptHelper
     fileName = inputArray.pop() # the last element is the file name
 
   @partialName: (fileNameWithoutExtensions) ->
-    if @editorExtension() is '.scss'
+    if @editorExtension() in ['.scss', '.sass']
       "_#{fileNameWithoutExtensions}#{@editorExtension()}"
     else
       "_#{fileNameWithoutExtensions}.html#{@editorExtension()}"

--- a/lib/rails-partials.coffee
+++ b/lib/rails-partials.coffee
@@ -55,6 +55,8 @@ module.exports =
     switch extension
       when '.scss'
         return "@import \"#{partialName}\";"
+      when '.sass'
+        return "@import #{partialName}"
       when '.haml'
         return "= render '#{partialName}'#{params}"
       when '.slim'

--- a/lib/rails-partials.coffee
+++ b/lib/rails-partials.coffee
@@ -2,6 +2,7 @@
 S = require 'string'
 Prompt = require './prompt'
 PromptHelper = require './prompt-helper'
+path = require 'path'
 
 module.exports =
   config:
@@ -51,10 +52,13 @@ module.exports =
 
     fileName = atom.workspace.getActiveTextEditor().getTitle()
     extension = path.extname(fileName)
-    if extension is '.scss'
-      # when scss add _ to partialName
-      "@import \"_#{partialName}\";"
-    else if extension is '.haml'
-      "= render \"#{partialName}\"#{params}"
-    else
-      "<%= render \"#{partialName}\"#{params} %>"
+    switch extension
+      when '.scss'
+        # when scss add _ to partialName
+        return "@import \"_#{partialName}\";"
+      when '.haml'
+        return "= render \"#{partialName}\"#{params}"
+      when '.slim'
+        return "== render \"#{partialName}\"#{params}"
+      else
+        return "<%= render \"#{partialName}\"#{params} %>"

--- a/lib/rails-partials.coffee
+++ b/lib/rails-partials.coffee
@@ -57,8 +57,8 @@ module.exports =
         # when scss add _ to partialName
         return "@import \"_#{partialName}\";"
       when '.haml'
-        return "= render \"#{partialName}\"#{params}"
+        return "= render '#{partialName}'#{params}"
       when '.slim'
-        return "== render \"#{partialName}\"#{params}"
+        return "== render '#{partialName}'#{params}"
       else
-        return "<%= render \"#{partialName}\"#{params} %>"
+        return "<%= render '#{partialName}'#{params} %>"

--- a/lib/rails-partials.coffee
+++ b/lib/rails-partials.coffee
@@ -54,8 +54,7 @@ module.exports =
     extension = path.extname(fileName)
     switch extension
       when '.scss'
-        # when scss add _ to partialName
-        return "@import \"_#{partialName}\";"
+        return "@import \"#{partialName}\";"
       when '.haml'
         return "= render '#{partialName}'#{params}"
       when '.slim'

--- a/spec/rails-partials-spec.coffee
+++ b/spec/rails-partials-spec.coffee
@@ -12,7 +12,6 @@ describe "RailsPartials", ->
   [editor, editorElement] = []
 
   beforeEach ->
-    atom.workspaceView = new WorkspaceView()
 
     waitsForPromise ->
       atom.workspace.open('index.html.erb')


### PR DESCRIPTION
* Removed underscore for partial name for SCSS.
* Also use single quote instead of double for Haml, Slim and ERB partials.
