### PR TITLE
Make quote style configurable

### DIFF
--- a/lib/rails-partials.coffee
+++ b/lib/rails-partials.coffee
@@ -8,6 +8,10 @@ module.exports =
     showPartialInNewTab:
       type: 'boolean'
       default: true
+    quoteStyle:
+      type: 'string'
+      default: 'single'
+      enum: ['single', 'double']
 
   prompt: null
 
@@ -91,8 +95,13 @@ module.exports =
       when '.sass'
         return "@import #{partialName}"
       when '.haml'
-        return "= render '#{partialName}'#{params}"
+        return "= render #{@quote partialName}#{params}"
       when '.slim'
-        return "== render '#{partialName}'#{params}"
+        return "== render #{@quote partialName}#{params}"
       else
-        return "<%= render '#{partialName}'#{params} %>"
+        return "<%= render #{@quote partialName}#{params} %>"
+
+  quote: (string) ->
+    style = atom.config.get('rails-partials.quoteStyle')
+    quoteChar = if style is 'double' then '\"' else '\''
+    "#{quoteChar}#{string}#{quoteChar}"


### PR DESCRIPTION
Resolves #13

This commit adds a 'Quote Style' setting to allow the user to select
between single and double-quote styles when rendering partials.
Single-quote is the default so as not to change the current behavior.
### Default setting

<img width="697" alt="quote-style" src="https://cloud.githubusercontent.com/assets/2344137/14005569/eaf43654-f13a-11e5-9452-c6aca8c70853.png">
### Available settings

<img width="711" alt="quote-style-open" src="https://cloud.githubusercontent.com/assets/2344137/14005573/eaf6d274-f13a-11e5-93d2-5d5e6e451766.png">
### Single quotes
#### Without params

<img width="189" alt="quote-style-single-no-params" src="https://cloud.githubusercontent.com/assets/2344137/14005572/eaf6ae52-f13a-11e5-90b0-7629e2563811.png">
#### With params

<img width="298" alt="quote-style-single-params" src="https://cloud.githubusercontent.com/assets/2344137/14005574/eaf7a424-f13a-11e5-9ed7-af654ee3d1c7.png">
### Double quotes
#### Without params

<img width="192" alt="quote-style-double-no-params" src="https://cloud.githubusercontent.com/assets/2344137/14005570/eaf578b6-f13a-11e5-850f-ab5a0800b94d.png">
#### With params

<img width="295" alt="quote-style-double-params" src="https://cloud.githubusercontent.com/assets/2344137/14005571/eaf6aa6a-f13a-11e5-8e77-9bfee6d18126.png">
